### PR TITLE
Manage jwt token for tests

### DIFF
--- a/hemApp/__init__.py
+++ b/hemApp/__init__.py
@@ -114,7 +114,11 @@ class Check(object):
         self.storage = storage
 
     def get_jwt(self, auth):
-        j = requests.post(auth['url'], data=auth['body'], headers=auth['headers'])
+        j = requests.post(
+            auth['url'], 
+            data=auth.get('body', None), 
+            headers=auth.get('headers', None)
+        )
         self.logger.debug(j.status_code)
         self.logger.debug(j.text)
         token = j.json().get(auth['field'], None)

--- a/hemApp/__init__.py
+++ b/hemApp/__init__.py
@@ -113,7 +113,7 @@ class Check(object):
         self.metrics = metrics
         self.storage = storage
 
-    def get_jwt(self, auth):
+    def get_jwt(self, auth={}):
         j = requests.post(
             auth['url'], 
             data=auth.get('body', None), 
@@ -126,7 +126,7 @@ class Check(object):
         self.logger.debug("storing token: {}".format(token))
 
 
-    def is_jwt_valid(self, auth):
+    def is_jwt_valid(self, auth={}):
         token = self.storage.get(auth.get('key', 'jwt'))
         if token == None:
             self.logger.debug("No token - therefore not valid")

--- a/hemApp/cli.py
+++ b/hemApp/cli.py
@@ -43,7 +43,8 @@ def main(**kwargs):
     logger.info("Frequency is {}".format(frequency))
     logger.info(config)
     while True:
-        duration = hemApp.run_tests(config, metrics)
+        storage = hemApp.HemStore()
+        duration = hemApp.run_tests(config, metrics, storage)
         try:
             if int(frequency - duration) > 0:
                 time.sleep(int(frequency - duration))

--- a/hemApp/cli.py
+++ b/hemApp/cli.py
@@ -28,10 +28,6 @@ def main(**kwargs):
 
     logging.getLogger().setLevel(level=loglevel)
     logger = logging.getLogger(__name__)
-    logger.debug('debug test')
-    logger.info('info test')
-    logger.warning('warning test')
-    logger.error('error test')
     config = hemApp.load_config(kwargs['config'])
 
 
@@ -42,8 +38,8 @@ def main(**kwargs):
     frequency = config['settings'].get('frequency', 30)
     logger.info("Frequency is {}".format(frequency))
     logger.info(config)
+    storage = hemApp.HemStore()
     while True:
-        storage = hemApp.HemStore()
         duration = hemApp.run_tests(config, metrics, storage)
         try:
             if int(frequency - duration) > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest
 coverage
 requests-mock
 mock
+pyjwt

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     description = ("HTTP Endpoint Monitor - keeping the loose ends tied up"),
     setup_requires = ['setuptools_scm', 'pytest', 'pytest-cov', 'requests-mock'],
     use_scm_version=True,
-    install_requires = ['PyYaml', 'pike', 'click', 'requests', 'dnspython'],
+    install_requires = ['PyYaml', 'pike', 'click', 'requests', 'dnspython', 'pyjwt'],
     license = "MIT",
     keywords = "monitor, http",
     #url = "http://packages.python.org/an_example_pypi_project",

--- a/tests/test_hem.py
+++ b/tests/test_hem.py
@@ -35,11 +35,12 @@ def test_check_mtls_invoke():
         assert response == 200
         assert type(timing) is datetime.timedelta
 def test_check_jwt_invoke():
+    hemstore = hemApp.HemStore()
     with requests_mock.mock() as m:
         m.get('https://1.1.1.1/', text="")
-        m.get('https://1.1.1.1/jwt', text='{"jwt":"token"}')
+        m.post('https://1.1.1.1/jwt', text='{"jwt":"token"}')
         test = {'path':'/', 'secure':True, 'verify':True, 'auth': {'type':'jwt', 'url':'https://1.1.1.1/jwt', 'field':'jwt'}}
-        check = hemApp.Check('test', test)
+        check = hemApp.Check('test', test, storage=hemstore)
         results = check.test_list(["1.1.1.1"])
         (response, timing) = results[0]
         assert results is not None

--- a/tests/test_hem.py
+++ b/tests/test_hem.py
@@ -34,6 +34,17 @@ def test_check_mtls_invoke():
         assert results is not None
         assert response == 200
         assert type(timing) is datetime.timedelta
+def test_check_jwt_invoke():
+    with requests_mock.mock() as m:
+        m.get('https://1.1.1.1/', text="")
+        m.get('https://1.1.1.1/jwt', text='{"jwt":"token"}')
+        test = {'path':'/', 'secure':True, 'verify':True, 'auth': {'type':'jwt', 'url':'https://1.1.1.1/jwt', 'field':'jwt'}}
+        check = hemApp.Check('test', test)
+        results = check.test_list(["1.1.1.1"])
+        (response, timing) = results[0]
+        assert results is not None
+        assert response == 200
+        assert type(timing) is datetime.timedelta
 def test_ssl_error():
     with requests_mock.mock() as m:
         m.get('https://1.1.1.1/', exc=requests.exceptions.SSLError)


### PR DESCRIPTION
Managing and refreshing jwt tokens - config now like:

```
  apijwt:
    auth:
      type: jwt
      url: https://jwt.example.com
      body: '{"client_id":"myclientid","client_secret":"supersecret"}'
      headers:
        content-type: application/json
      field: jwt
```

