### PR TITLE
Support for a boolean to include or exlude

### DIFF
--- a/hemApp/drivers/discovery_file.py
+++ b/hemApp/drivers/discovery_file.py
@@ -13,9 +13,14 @@ def hosts(**kwargs):
     try:
         with open(kwargs['name'], 'rt') as source_file:
             hosts = yaml.safe_load(source_file)
+            print(hosts)
             for host in hosts:
                 if 'key' in kwargs:
-                    results.append(host.get(kwargs['key']))
+                    if 'enabled_key' in kwargs:
+                        if host.get(kwargs['enabled_key'], True) == True:
+                            results.append(host.get(kwargs['key']))
+                    else:
+                        results.append(host.get(kwargs['key']))
                 else:
                     results.append(host)
     except FileNotFoundError:

--- a/tests/hosts_key.yaml
+++ b/tests/hosts_key.yaml
@@ -1,6 +1,11 @@
  - 
    hostname: host1.example.com
    type: web
+   check: true
+ - 
+   hostname: host0.example.com
+   type: web
+   check: false
  - 
    hostname: host2.example.com
    type: web

--- a/tests/test_driver_discovery_file.py
+++ b/tests/test_driver_discovery_file.py
@@ -45,6 +45,19 @@ def test_check_content_key():
     print(hosts)
     assert 'host1.example.com' in hosts
 
+def test_check_content_key_enable():
+    import hemApp
+    hosts = hemApp.discover_hosts({
+        "type":"file",
+        "name":"tests/hosts_key.yaml",
+        "enabled_key":"check",
+        "key":"hostname"})
+    assert type(hosts) == list
+    print(hosts)
+    assert 'host0.example.com' not in hosts
+    assert 'host1.example.com' in hosts
+    assert 'host2.example.com' in hosts
+
 def test_check_metrics(capsys):
     import hemApp
     metrics = hemApp.initialise_metrics({"type":"console"})


### PR DESCRIPTION
In the discovery arguments, set `enabled_key` to a key
containing a boolean value as to whether to include.
If there is no key an object is included